### PR TITLE
improved storageID lookup

### DIFF
--- a/check_snmp_synology.sh
+++ b/check_snmp_synology.sh
@@ -342,7 +342,7 @@ else
         RAIDStatus[$i]=$(echo "$syno" | grep $OID_RAIDStatus.$(($i-1)) | cut -d "=" -f2 | sed 's/^[ \t]*//;s/[ \t]*$//')
 
         storageName[$i]=$(echo "${RAIDName[$i]}" | sed -e 's/[[:blank:]]//g' | sed -e 's/\"//g' | sed 's/.*/\L&/')
-        storageID[$i]=$(echo "$syno_diskspace" | grep ${storageName[$i]} | cut -d "=" -f1 | rev | cut -d "." -f1 | rev)
+        storageID[$i]=$(echo "$syno_diskspace" | grep -E "= *${storageName[$i]} *$" | cut -d "=" -f1 | rev | cut -d "." -f1 | rev)
 
         if [ "${storageID[$i]}" != "" ] ; then
             storageSize[$i]=$(echo "$syno_diskspace" | grep "$OID_StorageSize.${storageID[$i]}" | cut -d "=" -f2 )


### PR DESCRIPTION
The patch should fix a problem which was caused by multiple matches for the `storageID' parameter
due to a too generous grep statement. With the modification it is more likely that only one match is
returned. Additionally it should solve the problem that a grep for "volume1" also matches "volume10".

.1.3.6.1.2.1.25.2.3.1.3.38 = /volume1
.1.3.6.1.2.1.25.2.3.1.3.50 = /tmp/timebkp_23967/volume1
